### PR TITLE
Fix for md format

### DIFF
--- a/part1.md
+++ b/part1.md
@@ -1,4 +1,4 @@
-#Solr vs. ElasticSearch: Part 1 – 概観
+# Solr vs. ElasticSearch: Part 1 – 概観
 
 August 23, 2012 by [Rafał Kuć](http://blog.sematext.com/author/kucrafal/ "http://blog.sematext.com/author/kucrafal/")
 
@@ -20,19 +20,19 @@ Apache Lucene 4.0のリリースが近づくにつれ、それと共にSolr 4.0�
 5. Solr vs. ElasticSearch: Part 5 - 管理APIの機能
 6. Solr vs. ElasticSearch: Part 6 – ユーザと開発者のコミュニティ比較
 
-##はじめる前に
+## はじめる前に
 
 This post is based on released versions of Solr and ElasticSearch. For Solr, all the functionality description is based on version 4.0 beta and all of the ElasticSearch functionality is based on 0.19.8. Because we are comparing ElasticSearch and Solr, on the Solr side the focus is on Solr 4.0 (aka SolrCloud) functionality functionality and not Solr 3.*, so we could call this series as SolrCloud vs. ElasticSearch, too.
 
 このポストは以下のバージョンに基づいている。Solrの全ての機能記述はバージョン4.0βに基づき、ElasticSearchの全ての機能記述はバージョン0.19.8に基づく。ElasticSearchとSolrを比較するのだからSolrはSolrCloudとして知られるSolr 4.0にフォーカスする。Solr 3.*ではない。そのため我々はこの一連の記事をSolrCloud vs. ElasticSearchとも呼べるだろう。
 
-##検索エンジンの裏側
+## 検索エンジンの裏側
 
 For indexing and searching both Solr and ElasticSearch use Lucene. As you may suspect, Solr 4.0 beta uses the 4.0 version of Lucene, while ElasticSearch 0.19.8 still uses version 3.6.  Of course, that doesn’t mean much when it comes to future versions of ElasticSearch because you can be sure that ElasticSearch will start using Lucene 4.0 once it’s GA release is ready, or maybe even before that.
 
 インデックス作成と検索にはSolrとElasticSearchの両方がLuceneを用いる。お気づきだろうがSolr4.0βはLucene 4.0を用いるが、ElasticSearch 0.19.8は依然v3.6を用いている。もちろんそれはElasticSearchの将来のバージョンについては多くの意味を持たないだろう。Lucene 4.0のGAリリースの準備が終われば直ぐに（または恐らくそのずっと前から）ElasticSearchもまたそれを使い始めることが確実だからだ。
 
-##基本
+## 基本
 
 There are a few differences in the way Solr and ElasticSearch name certain concepts. Let’s start with the basics – many servers connected together forms a cluster for both ElasticSearch and Solr. A single instance of Solr or ElasticSearch is called a node. That’s about it for nomenclature overlap.
 
@@ -46,7 +46,7 @@ On the other hand we have ElasticSearch where the top logical data structure is 
 
 一方、ElasticSearchはインデックスと呼ばれる論理的なデータ構造の上にある。Solrのコレクションに似て、ElasticSearchのインデックスは複数のshardとレプリカを持つことが可能である。そしてShardとレプリカはまた小さなLuceneのインデックスであり、クラスタ上で分散され、分散環境を構築する。しかしそれだけではない。ElasticSearchでは1つのインデックス上に複数の型のドキュメントを持つことができる。これは異なるインデックス構造の複数のドキュメント（例えばユーザと彼らのドキュメント）を単一のインデックスに索引付けできることを意味する。ElasticSearchはインデックス作成時にもまた検索時にもそれらの型の区別を付けることが可能だ。Solrで同じことをするにはアプリケーションの中でそれをシミュレートするか、カスタム検索コンポーネントを開発する必要があるだろう。
 
-##設定
+## 設定
 
 Lets take a quick look at how Solr and ElasticSearch are configured. Let’s start with the index structure.
 
@@ -64,7 +64,7 @@ Let’s talk about the actual configuration of Solr and ElasticSearch for a bit.
 
 SolrとElasticSearchの実際の設定についてもう少し話を続けよう。Solrでは全てのコンポーネント、検索ハンドラ、インデックス特定の物事（例えばマージファクタやバッファ、キャッシュ等）の定義は、solrconfig.xmlファイルの中に定義される。全ての変更の後にはSolrノードの再起動かリロードが必要である。ElasticSearchの設定全てはelasticsearch.ymlファイルに記述される。それはまた別の設定ファイルに過ぎない。しかしElasticSearchの設定を定義、又は変更する方法はそれだけではない。ElasticSearchにおける多くの設定（しかし全てでは無い）は運用中のクラスタ上にて変更可能だ。例えばShardとレプリカをクラスタ内部のどこに置くかである。またElasticSearchのノードは再起動する必要がない。このことについてはElasticSearchのShardの配置コントロールにおいてより詳しく学ぶ。
 
-##探索とクラスタの管理
+## 探索とクラスタの管理
 
 Solr and ElasticSearch have a different approach to cluster node discovery and cluster management in general.  The main purpose of discovery is to monitor nodes’ states, choose master nodes, and in some cases also store shared configuration files.
 
@@ -82,7 +82,7 @@ There is one thing worth noting when it comes to cluster handling – the split 
 
 1つ注意すべきことがクラスタの取扱いにある。スプリットブレインという状態だ。クラスタが半分に分割されてノードの半分が、一方の半分を検知できない状態を想像して欲しい。例えばネットワークの障害だ。そのようなケースではElasticSearchはマスターノードを持たないほうの部分クラスタにおいて新しいマスターを選択しようと試みる。これが2つの独立したクラスタが同時に実行される状況へと導く。これは少ない量の定義で制限できるが、それでも起こりうる。一方でSolr4.0はスプリットブレイン状態に免疫がある。ZooKeeperを用いているため、そのような状態を防いでくれる。もし半分のSolrクラスタが接続不能に陥った場合、ZooKeeperにはそれが見えず、従ってデータとクエリはそちらには転送されない。
 
-##API
+## API
 
 If you know Apache Solr or ElasticSearch you know that they expose an HTTP API.
 
@@ -96,7 +96,7 @@ And what about ElasticSearch?  ElasticSearch exposes a REST API which can be acc
 
 ElasticSearchについてはどうだろうか？ ElasticSearchはHTTPのGET、DELETE、POST、PUTメソッドを用いてアクセスできるREST APIを公開している。ドキュメントにクエリをかけたり削除するだけでなく、インデックスを作成したり管理したり分析をコントロールして現在の状態を表すメトリクスを全て取得したりElasticSearchの設定を取得したりもできる。もしElasticSearchについて何か知りたいことがあればREST APIを通して取得可能だ。（我々はそれを自社の"Scalable Performance Monitoring for ElasticSearch"でも使っている！）もしあなたがSolrに慣れ親しんでいるのなら最初におかしく感じることが1つあるだろう。ElasticSearchのレスポンスにはJSONフォーマットしか存在しない。例えばXMLは無い。ElasticSearchとSolrの他の大きな違いはクエリだ。Solrでは全てのクエリパラメータがURLパラメータとして渡さえるのに対し、ElasticSearchのクエリではJSON表現にて構成される。JSONオブジェクトとしてクエリを構成することでElasticSearchがどのようにクエリを理解し、そしてどのような結果を返すかの数多くのコントロールを提供する。
 
-##データの取扱い
+## データの取扱い
 
 Of course, both Solr and ElasticSearch leverage Lucene near real-time capabilities.  This makes it possible for queries to match documents right after they’ve been indexed. In addition to that, both Solr (since 4.0) and ElasticSearch (since 0.15) allow versioning of documents in the index.  This feature allows them to support optimistic locking and thus enable prevention of overwriting updates. Let’s look at how distributed indexing is done in Solr vs. ElastiSearch.
 
@@ -115,7 +115,7 @@ Of course, both Solr and ElasticSearch allow one to configure replicas of indice
 
 もちろん、SolrとElasticSearchの両方がインデックス（ElasticSearch)、またはコレクション（Solr）のレプリカの設定を許可している。これはレプリカがクラスタの高可用性を実現していることからとても重要だ。例えいくつかのノードがハードウェア障害やメンテナンスにてダウンしても、クラスタとその中のデータは利用可能であり続ける。レプリカ無しでは1つのノードが失なわれたら、失なわれたノード上に存在したデータ（に対するアクセス）は失なわれる。もし設定にレプリカが存在する場合、両検索エンジンは自動的にドキュメントをレプリカにコピーするので、データロスについて心配する必要はない。
 
-##まとめ
+## まとめ
 
 
 We hope that after reading this post you have the basic understanding of what you can expect from both Solr 4.0 and ElasticSearch 0.19.* and you can start to get the feeling for differences and similarities between them.  Of course,  both Solr and ElasticSearch have very strong and active user and development communities and are constantly evolving and improving, and are doing that rather fast. In pre-Solr 4.0 (aka SolrCloud) world the difference between Solr and ElasticSearch was quite stark.  Since then, and under the pressure from ElasticSearch, the gap has narrowed and both projects are moving forward quite quickly.  At Sematext our clients often ask us to recommend the search engine for their use and we recommend both of them.  Which one we recommend for a particular project depends on project requirements, which we always go through at the beginning of every engagement.  If you need help deciding, let us know.

--- a/part2.md
+++ b/part2.md
@@ -1,4 +1,4 @@
-#Solr vs. ElasticSearch: Part 2 – Data Handling
+# Solr vs. ElasticSearch: Part 2 – Data Handling
 
 September 4, 2012 by Rafał Kuć 25 Comments
 
@@ -13,14 +13,14 @@ In the previous part of Solr vs. ElasticSearch series we talked about general ar
 5. Solr vs. ElasticSearch: Part 5 - Management API Capabilities
 6. Solr vs. ElasticSearch: Part 6 – User & Dev Communities Compared
 
-##データのインデックス作成
+## データのインデックス作成
 
 Apart from using Java API exposed both by ElasticSearch and Apache Solr, you can index data using an HTTP call. To index data in ElasticSearch you need to prepare your data in JSON format. Solr also allows that, but in addition to that, it lets you to use other formats like the default XML or CSV. Importantly, indexing data in different formats has different performance characteristics, but that comes with some limitations. For example, indexing documents in CSV format is considered to be the fastest, but you can’t use field value boosting while using that format. Of course, one will usually use some kind of a library or Java API to index data as one doesn’t typically store data in a way that allows indexing of data straight into the search engine (at least in most cases that’s true).
 
 
 ElasticSearchとApache Solrの両者により公開されるJava APIの使用から離れて、HTTPの呼出を用いてデータのインデックス作成を行うことが可能だ。ElasticSearchにおいてデータのインデックスを作成するにはデータをJSONフォーマットに準備する必要がある。Solrもまたそれが可能だが、それに付け加えてデフォルトのXMLやCSV等、他の形式を利用することが可能だ。重要なこととして、異なる形式のデータのインデックスを作成する場合、異なるパフォーマンスの特性が存在する。しかしそれはいくらかの制約と共に存在する。例えばCSV形式のドキュメントのインデックスを作成する場合、最も速いと考えられるが、その形式を用いる場合にフィールド値のboostingを利用することができない。もちろん通常は何らかの種類のライブラリやJava APIを用いてデータのインデックス作成をするだろう。一般的に検索エンジンに直接入るデータのインデックスを作成しながらデータを格納することは無いだろう。（少なくとも多くの場合はそれが真実だ）
 
-##ElasticSearchについて補足
+## ElasticSearchについて補足
 
 It is worth noting that ElasticSearch supports two additional things, that Solr does not – nested documents and multiple document types inside a single index.
 
@@ -35,14 +35,14 @@ Multiple types of documents per index allow just what the name says – you can 
 インデックス当りの複数タイプドキュメントは名前どおりのことを可能にする。異なるタイプのドキュメントを同じインデックス内に索引付けすることが可能だ。これはSolrでは不可能で、Solrはコア当たりに1つのスキーマを持つことしかできない。ElasticSearchではドキュメントタイプによりフィルタ、クエリ、ファセットを行うことができる。全てのドキュメントタイプに対して、または1つのドキュメントタイプを選択してクエリを行うことができる。（Java APIとRESTの両方で可能である。）
 
 
-##インデックスの操作
+## インデックスの操作
 
 Let’s look at the ability to manage your indices/collections using the HTTP API of both Apache Solr and ElasticSearch.
 
 Apache SolrとElasticSearchの両者にてインデックス／コレクションをHTTP APIを用いて管理する能力を見てみよう
 
 
-###Solr
+### Solr
 
 Solr let’s you control all cores that live inside your cluster with the CoreAdmin API – you can create cores, rename, reload, or even merge them into another core. In addition to the CoreAdmin API Solr enables you to use the collections API to create, delete or reload a collection. The collections API uses CoreAdmin API under the hood, but it’s a simpler way to control your collections. Remember that you need to have your configuration pushed into ZooKeeper ensemble in order to create a collection with a new configuration.
 
@@ -52,18 +52,18 @@ When it comes to Solr, there is additional functionality that is in early stages
 
 Solrにはまだ未熟な段階ではあるが有効な追加の機能がある。Shardの分割だ。SOLR-3755に存在するパッチを当てた後にインデックスを分割して2つの分離したコアに書き込むことがSPLITアクションを用いて可能になる。そのJIRAのイシューを読めばこれがコミットされればSolrは新しいレプリカを作成するだけでなく、動的にインデックスをre-shardする機能を持つことになるだろう。これはとても大きい。
 
-###ElasticSearch
+### ElasticSearch
 
 One of the great things in ElasticSearch is the ability to control your indices using HTTP API. We will take about it extensively in the last part of the series, but I have to mention it ere, too. In ElasticSearch you can create indices on the live cluster and delete them. During creation you can specify the number of shards an index should have and you can decrease and increase the number of replicas without anything more than a single API call. You cannot change the number of shards yet.  Of course, you can also define mappings and analyzers during index creation, so you have all the control you need to index a new type of data into you cluster.
 ElasticSearchの素晴しい機能の1つにHTTP APIを用いてインデックスをコントロールする能力がある。このシリーズの最後のパートにて広範にそれについて触れるがここでも触れておく必要があるだろう。ElasticSearchでは運用中のクラスタ上にてインデックスを作成し、消すことが可能だ。作成の間にインデックスが持つべきShardの数を指定可能で、単一のAPI呼出のみでレプリカの数の増減が可能だ。Shardの数はまだ変更できない。もちろんマッピングと解析器をインデックス作成時に設定可能で、クラスタ内に新しい型のデータの索引付けに必要な全てのコントロールを持つことになる。
 
-##ドキュメントの部分更新
+## ドキュメントの部分更新
 
 Both search engines support partial document update. This is not the true partial document update that everyone has been after for years – this is really just normal document reindexing, but performed on the search engine side, so it feels like a real update.
 
 両方の検索エンジンがドキュメントの部分更新をサポートする。これは皆が期待する真のドキュメント部分更新ではない。単なる通常のドキュメントのインデックス再作成である。しかし検索エンジンサイドで実行されるので本物の更新に感じる。
 
-###Solr
+### Solr
 
 Let’s start from the requirements – because this functionality reconstructs the document on the server side you need to have your fields set as stored and you have to have the _version_ field available in your index structure. Then you can update a document with a simple API call, for example:
 
@@ -73,7 +73,7 @@ Let’s start from the requirements – because this functionality reconstructs 
 
 	curl 'localhost:8983/solr/update' -H 'Content-type:application/json' -d '[{"id":"1","price":{"set":100}}]'
 
-###ElasticSearch
+### ElasticSearch
 
 In case of ElasticSearch you need to have the _source field enabled for the partial update functionality to work. This _source is a special ElasticSearch field that stores the original JSON document.  Theis functionality doesn’t have add/set/delete command, but instead lets you use script to modify a document. For example, the following command updates the same document that we updated with the above Solr request:
 
@@ -86,14 +86,14 @@ ElasticSearchの場合、部分更新の機能が働くためには_sourceフィ
 	    }
 	}'
 
-##多国語データの取扱
+## 多国語データの取扱
 
 As we mentioned previously, and as you probably know, both ElasticSearch and Solr use Apache Lucene to index and search data. But, of course, each search engine has its own Java implementation that interacts with Lucene. This is also the case when it comes to language handling. Apache Solr 4.0 beta has the advantage over ElasticSearch because it can handle more languages out of the box. For example, my native language Polish is supported by Solr out of the box (with two different filters for stemming), but not by ElasticSearch. On the other hand, there are many plugins for ElasticSearch that enable support for languages not supported by default, though still not as many as we can find supported in Solr out of the box.  It’s also worth mentioning there are commercial analyzers that plug into Solr (and Lucene), but none that we are aware of work with ElasticSearch…. yet.
 
 
 以前述べたとおり、そして恐らくご存知のとおり、ElasticSearchとSolrはApache Luceneをインデックス作成とデータの検索に用いている。しかし、もちろん各検索エンジンはそれ自身のJava実装を持ちそれがLuceneと相互作用している。これが各国語の取扱においても同じである。Apache Solr 4.0βがElasticSearchに対して優位である。そのままでより多くの言語を扱うことができるからだ。例えば筆者のネイティブ言語であるポーランド語はSolrでは最初からサポートされている。（2つの異なるstemming用フィルタ付きで。）しかしElasticSearchはそうではない。一方で、ElasticSearchにはデフォルトではサポートされない言語をサポートするプラグインが多く有る。それでもその数はSolrが最初からサポートしている数程は無い。もう一つ記述しておく価値があるのはSolr（とLucene）には商業解析器がある。しかしElasticSearch向けの物を筆者はまだ知らない。
 
-##サポートされる自然言語
+## サポートされる自然言語
 For the full list of languages supported by those two search engine please refer to the following pages:
 2つの検索エンジンにてサポートされる言語の完全なリストについては次のページを参照して欲しい。
 
@@ -106,13 +106,13 @@ Analyzers: [http://www.elasticsearch.org/guide/reference/index-modules/analysis/
 Stemming: [http://www.elasticsearch.org/guide/reference/index-modules/analysis/stemmer-tokenfilter.html](http://www.elasticsearch.org/guide/reference/index-modules/analysis/stemmer-tokenfilter.html),
  [http://www.elasticsearch.org/guide/reference/index-modules/analysis/snowball-tokenfilter.html](http://www.elasticsearch.org/guide/reference/index-modules/analysis/snowball-tokenfilter.html) それに [http://www.elasticsearch.org/guide/reference/index-modules/analysis/kstem-tokenfilter.html](http://www.elasticsearch.org/guide/reference/index-modules/analysis/snowball-tokenfilter.html)
 
-##解析チェインの定義
+## 解析チェインの定義
 
 Of course, both Apache Solr and ElasticSearch allow you to define a custom analysis chain by specifying your own analyzer/tokenizer and list of filters that should be used to process your data. However, the difference between ElasticSearch and Solr is not only in the list of supported languages. ElasticSearch allows one to specify the analyzer per document and per query. So, if you need to use a different analyzer for each document in the index you can do that in ElasticSearch. The same applies to queries – each query can use a different analyzer.
 
 もちろん、Apache SolrとElasticSearchの両方がカスタム解析器のチェインを定義できる。あなたのデータ処理に使用される解析器及びトークナイザ、フィルタのリストを指定する。しかしElasticSearchとSolrの違いはサポートされる言語のリスト中だけではない。ElasticSearchはドキュメント毎、クエリ毎に解析器を指定することが可能だ。そのためインデックス中の個別のドキュメントに異なる解析器の使用が必要なら、ElasticSearchではそれが可能だ。同じことがクエリにも言える。各クエリは異なる解析器を使用できる。
 
-##結果のグルーピング
+## 結果のグルーピング
 
 One of the most requested features for Apache Solr was result grouping. It was highly anticipated for Solr and it is still anticipated for ElasticSearch, which doesn’t yet have field grouping as of this writing.  You can see the number of +1 votes in the following issue: https://github.com/elasticsearch/elasticsearch/issues/256.  You can expect grouping to be supported in ElasticSearch after changes introduced in 0.20. If you are not familiar with results grouping – it allows you to group results based on the value of a field, value of a query, or a function and return matching documents as  groups. You can imagine grouping results of restaurants on the value of the city field and returning only five restaurants for each city. A feature like this may be handy in some situations. Currently, for the search engines we are talking about, only Apache Solr supports results grouping out of the box.
 
@@ -120,7 +120,7 @@ Apache Solrに最もリクエストされた機能の1つが結果のグルー�
 ElasticSearchには0.20の変更が紹介された時にはサポートされることが期待できあるであろう。
 結果のグルーピングを知らない人に説明すると、それはフィールドやクエリ、または関数の値によって結果をグループに分けることが可能になる。そしてマッチしたドキュメントをグループにして返す。例えばレストランの結果を街のフィールドでグルーピングし、各街の5つのレストランだけを返す。このような機能はいくつかのシチュエーションにて便利だろう。現在はApache Solrのみがそのままの状態で結果のグルーピングを持っている。
 
-##Prospective Search
+## Prospective Search
 
 One thing Apache Solr completely lacks when comparing to ElasticSearch is functionality called Percolator in ElasticSearch. Imagine a search engine that, instead of storing documents in the index, stores queries and lets you check which stored/indexed queries match each new document being indexed. Sound handy, right?  For example, this is useful when people want to watch out for any new documents (think Social Media, News, etc.) matching their topics of interest, as described through queries. This functionality is also called Prospective Search, some call it Pub-Sub as well as Stored Searches.  At Sematext we’ve implemented this a few times for our clients using Solr, but ElasticSearch has this functionality built-in.  If you want to know more about ElasticSearch Percolator see http://www.elasticsearch.org/blog/2011/02/08/percolator.html.
 
@@ -128,7 +128,7 @@ Apache SolrがElasticSearchに比べて完全に欠いているものの1つはE
 これが便利なのは、例えばユーザが全ての新しいドキュメント（ソーシャルメディアやニュース等を考えよう）がユーザの興味が有るトピックに属するか、先程記述したクエリを通してチェックしたい場合等だ。この機能はまたProspective Searchとも呼ばれる。またある人はPub-Subと呼ぶし、stored searchとも呼ばれる。Sematextでは我々のSolrを使う顧客のためにこれを何度か実装したことがある。しかしElasticSearchは最初から組み込みでこの機能を持っている。もしElasticSearchのパーコレータについてもっと知りたければ次を参照すること。
 [http://www.elasticsearch.org/blog/2011/02/08/percolator.html](http://www.elasticsearch.org/blog/2011/02/08/percolator.html)
 
-##次回予告
+## 次回予告
 
 In the next part of the series we will focus on comparing the ability to query your indices and leverage the full text search capabilities of Apache Solr and ElasticSearch. We will also look at the possibility to influence Lucene scoring algorithms during query time. Till next time :)
 

--- a/part3.md
+++ b/part3.md
@@ -1,4 +1,4 @@
-#Solr vs ElasticSearch: Part 3 – 検索
+# Solr vs ElasticSearch: Part 3 – 検索
 
 October 1, 2012 by Rafał Kuć 8 Comments
 
@@ -13,16 +13,16 @@ In the last two parts of the series we looked at the general architecture and ho
 5. Solr vs. ElasticSearch: Part 5 - Management API Capabilities
 6. Solr vs. ElasticSearch: Part 6 – User & Dev Communities Compared
 
-##全体的なアプローチ
+## 全体的なアプローチ
 
 Both search engines expose their search APIs via HTTP. If you are not familiar with Solr or ElasticSearch, here are a few simple examples of what Apache Solr and ElasticSearch queries look like:
 
 両方の検索エンジンがHTTPを経由して検索APIを公開している。SolrやElasticSearchを良く知らない場合のため、ここからいくつか、Apache SolrとElasticSearchのクエリがどのような物か、簡単な例を示す。
 
-###Solr
+### Solr
 	curl -XGET 'http://localhost:8983/solr/sematext/select?q=post_date:[2012-09-10T12:00:00Z+TO+2012-09-10T15:00:00Z]'
 
-###ElasticSearch
+### ElasticSearch
 
 	curl -XGET http://localhost:9200/sematext/_search?pretty=true -d '{
 	    "query" : {
@@ -43,44 +43,44 @@ To sum up our short introduction – both search engines give you a similar degr
 
 我々の短いイントロをまとめると、両方の検索エンジンが同じ程度のコントロールをクエリに対して提供する。しかしスクラッチからクエリを作成し、Luceneを直接利用する様に全ての局面をコントロールしたい場合、ElasticSearchを選択するべきだ。Solrではできないからではなく、ElasticSearchの提供する構造化されたJSONの仕組みがそのケースにはよりフィットし、より直感的に感じられるからだ。
 
-##全文検索
+## 全文検索
 
 In this section we try to compare search capabilities of both both Apache Solr and ElasticSearch. This is by no means a comprehensive tutorial of all the features that both search engines expose, but rather  a simple comparison of similarities and difference of them.
 
 このセクションではApache SolrとElasticSearchの両方の検索能力を比較することを試みる。これはもちろん包括的な両方の検索エンジンの持つ全ての機能のチュートリアルではない。どちらかと言えば簡単な類似点と相違点の比較に過ぎない。
 
-###検索
+### 検索
 
 Of course, both Apache Solr and ElasticSearch enable you to run standard queries such as Boolean queries, phrase queries, fuzzy queries, wildcard queries, etc. You can combine them into multiple Boolean phrases using Boolean operators. In addition to that, both engine let one specify query-time boosts and control how score is calculated during search execution.
 
 もちろん、Apache SolrとElasticSearchの両者共、標準的な検索が可能だ。ブーリアンクエリ、フレーズクエリ、ファジークエリ、ワイルドカードクエリ等である。Boolean演算子を用いてそれらを結合して複数のブーリアンフレーズに結合することも可能だ。加えて両方のエンジンはクエリ時のboostを指定し、検索実行中にどのようにスコアが計算されるかをコントロールすることができる。
 
-###Span Queries
+### Span Queries
 
 If you are not familiar with span queries here is a one-sentence description: Lucene provides span queries in order to enable searching documents with position requirements, but not necessarily appearing one after another like in the phrase query. And now the comparison:
 
 スパンクエリを知らない人に簡単に説明すると、Luceneが提供するスパンクエリは位置を必要とするドキュメント検索を可能にする。しかしフレーズクエリのように連続して表れる必要は無い。
 では比較してみよう
 
-####Solr
+#### Solr
 
 Update: As Erik Hatcher noticed support for span queries is already there in Apache Solr (SOLR-2703). We can use span queries by using the surround query parser.
 
 更新： Erik Hatcherによるとスパンクエリは既にApache Solrに入っている。(SOLR-2703)。クエリパーザにて囲むことでスパンクエリを使用可能だ。
 
-####ElasticSearch
+#### ElasticSearch
 
 ElasticSearch has the support for Lucene SpanNearQuery, SpanFirstQuery, SpanTermQuery, SpanOrQuery and SpanNotQuery. With these queries you can construct different span queries similar to what you can do with Lucene.
 
 ElasticSearchはLuceneのSpanNearQuery、SpanFristQuery、SpanTermQuery、SpanOrQuery、そしてSpanNotQueryをサポートする。これらのクエリを用いてLuceneで行えるような異なるスパンクエリを構築することが可能だ。
 
-###More Like This
+### More Like This
 
 “More like this” (aka MLT) functionality lets you to get documents similar to a given query according to some assumptions and parameters used to find documents that are similar to one another. Both search engines have the ability to run MLT queries. In Solr, MLT  query is implemented as a search component. On the other hand there is ElasticSearch where more like this is just another type of query one can construct using JSON. When comparing parameters available in both search servers it seems that ElasticSearch provides slightly more control over more like this functionality with features like specifying a set of words that shouldn’t be taken into consideration and the percentage of terms to match on.
 
 "More like this"(またはMLT)とはクエリにて与えらたドキュメントに、いくつかの想定で似たドキュメントを得る機能だ。相似なドキュメントの発見にはパラメータが用いられる。両方の検索エンジンがMLTクエリを実行可能だ。SolrではMITクエリは検索コンポーネントとして実装されている。一方、ElasticSearchではJSONを用いて構築する1つの種類のクエリとなる。両者の検索サーバに存在するパラメータを比較するとElasticSearchはわずかに多くのコントロールを提供する。例えば考慮に入れてはいけない単語の集合を指定したり、マッチする項目の割合を指定可能だ。
 
-###Did You Mean
+### Did You Mean
 
 “Did you mean” (aka DYM) functionality makes it possible to correct users’ query typos and spelling mistakes and suggest corrected queries. For example, for a misspelled phrase “saerch problems” our Researcher module on http://search-lucene.com (which is a kind of a did you mean module) works like this:
 
@@ -90,27 +90,27 @@ Let’s see what Solr and ElasticSearch have to offer here.
 
 SolrとElasticSearchにどのような機能が提供されているか見てみよう。
 
-####Solr
+#### Solr
 
 Solr exposes spell check component API, which is built on top of Lucene spell checker module. Before Solr 4.0 the spell checker required its own index that, while built automatically by Solr, was another moving piece and potential inconvenience.  Now there is a DirectSolrSpellchecker implementation available which can give spell checker suggestion based on the index you are using for search instead of relying on the side-car spell checker index. Solr spell checker supports distributed search and has numerous parameters which allow control over its behavior, like number of suggestion, collation properties, accuracy, etc.
 
 SolrはスペルチェックコンポーネントAPIを提供する。それはLuceneのスペルチェッカーモジュールの上に構築されている。Solr 4.0以前ではスペルチェッカーはそれ自身のインデックスを必要とし、Solrにより自動的に構築されるが、別に動作する部品であり恐らく不便なものだった。今はDirectSolrSpellcheckerの実装が存在し、検索に使用しているインデックスに基づきスペルチェッカーが提案を行うことが可能だ。スペルチェッカー用のインデックスを必要としない。Solrのスペルチェッカーは分散検索をサポートし、多くのパラメータを持つことでその動作をコントロールできる。例えば提案の数や照合のプロパティや正確性等である。
 
-####ElasticSearch
+#### ElasticSearch
 
 Unfortunately, ElasticSearch doesn’t offer did you mean functionality out of the box. There is issue  #911 currently open, so we can expect that module in one of the future releases. Although we’ll be talking about plug-ins in the last part of the Solr vs ElasticSearch series, if you need did you mean functionality in ElasticSearch you can use the Suggest Plugin developed by @spinscale (https://github.com/spinscale/elasticsearch-suggest-plugin).
 
 残念だがElasticSearchは“Did you mean”の機能をそのままでは提供しない。Issue#911が現在オープンしており将来のリリースでそのモジュールを期待できるだろう。Solr vs ElasticSearchの最後のパートにてプラグインについて話すが、もしあなたが“Did you mean”の機能をElasticSearchにて必要とするのならば@spinscaleが開発したSuggestプラグインを利用することが可能だ。(https://github.com/spinscale/elasticsearch-suggest-plugin).
 
-###Nested Queries
+### Nested Queries
 
 As we already wrote, ElasticSearch supports indexing of nested document which Solr doesn’t support. In order to query nested documents ElasticSearch exposes nested query type. This query is run against nested documents, but as the result we get the root documents. In addition to that, you can also set how scoring of the root document is affected.
 
 既に書いたがElasticSearchは入れ子のドキュメントのインデックス作成をサポートする。Solrはサポートしない。入れ子ドキュメントをクエリするためにElasticSearchは入れ子クエリタイプを公開している。このクエリは入れ子ドキュメントに対し実行されるが結果としてルートドキュメントを得ることになる。これに加えてルートドキュメントのスコアリングにどのように影響されるかも設定可能だ。
 
 
-###Parent – Child Relationship Queries
-####Solr
+### Parent – Child Relationship Queries
+#### Solr
 
 In Apache Solr there is no functionality called parent - child, instead of that we have the possibility to use joins. Solr joins are specified in local params format and look like this:
 
@@ -122,14 +122,14 @@ The above query says that we want to get all parent documents that have child do
 
 上のクエリではcolorフィールドにYellowを持つ子ドキュメントを持つ全ての親ドキュメントを得る。joinは子ドキュメントのparentフィールドから親ドキュメントのidフィールド上にて行われるはずだ。
 
-####ElasticSearch
+#### ElasticSearch
 
 ElasticSearch lets you use two type of queries – has_children and top_children queries to operate on child documents. The first query accepts a query expressed in ElasticSearch Query DSL as well as the child type and it results in all parent documents that have children matching the given query. The second type of query is run against a set number of children documents and then they are aggregated into parent documents. We are also allowed to choose score calculation for the second query type.
 
 ElasticSearchは2つのタイプのクエリを使用可能だ。has_childrenとtop_childrenのクエリは子ドキュメント上にて命令される。最初のクエリはElasticSearch Query DSLまたはchildタイプで表現されたクエリを受け付け、与えられたクエリにマッチする子ドキュメントを持つ全ての親ドキュメントを結果とする。2つ目のタイプのクエリはいくつかの子ドキュメントの集合に対し実行されそれらは親ドキュメントの中に集約される。2つ目のクエリタイプに対してもスコア演算を選択することが許可されています。
 
-###Filtering And Caching Control
-####Solr
+### Filtering And Caching Control
+#### Solr
 
 Of course Solr lets you to narrow results of your query execution with filters. You can filter documents based on a single value, Boolean expression, query, field existence, geographical location and many, many more. In addition to that you can use local params and construct complicated queries like:
 
@@ -138,37 +138,37 @@ Of course Solr lets you to narrow results of your query execution with filters. 
 
 	fq={!frange l=10 u=30}if(exists(promotionPrice),sum(promotionPrice,dailyPrice),sum(price,dailyPrice))
 
-####ElasticSearch
+#### ElasticSearch
 
 ElasticSearch, similar to Solr, lets you use many filter types, which are similar to filters, so we’ll skip mentioning them all. However, in addition to similarities with Solr, there are also some differences like supports for filters run against nested documents and children documents. ElasticSearch can also use scripts to filter documents with the script filter.
 
 
 ElasticSearchはSolrに似て多くのフィルタタイプを用いることができる。それはフィルタと同様なので全てを語る必要がない。しかしSolrに対する類似性に加えて、いくつかの異なる点が存在する。例えば入れ子ドキュメントや子ドキュメントに対して実行するフィルタのサポートである。ElasticSearchはまたスクリプトフィルタを用いてドキュメントのフィルタリングにスクリプトを使用することも可能だ。
 
-###Filter Cache Control
+### Filter Cache Control
 Both ElasticSearch and Apache Solr can control if the filter should or shouldn’t be cached, but in addition to that Solr lets you control the order of filters execution (the non cached ones). Its a great feature of Solr, because if you know that one of your filters is a performance killer, you can set its execution after all other filters and that way it’ll only work on the subset of the original result set.
 
 ElasticSearchとApache Solrの両方でフィルタがキャッシュされるべきかそうでないかをコントロール可能だ。加えてSolrはフィルタの実行順をコントロールできる。（キャッシュされていないもののみ）これはSolrの優れた機能でもしあなたのフィルタの1つがパフォーマンスに悪い影響を与えることが事前にわかっていればそのフィルタの実行を他の全ての後に設定可能だ。そうすることでそのフィルタはオリジナルの実行結果の部分集合のみを対象に実行されることになる。
 
-###Score Calculation Control
+### Score Calculation Control
 
 In both engines we are more or less allowed to control how scores for documents are calculated. In Solr this is mostly done by using function queries and different boosts and queries made using local params. In ElasticSearch we can use different query types which allow us to give specific scores to some of the documents (for example ones matching a certain filter) or calculate score on the basis of used script.
 
 両方のエンジンにおいて多かれ少なかれドキュメントに対するスコアがどのように演算されるかをコントロールすることが可能だ。Solrではこれは多くの場合においてファンクションクエリか複数の異なるboostを用いて行われ、クエリはローカルパラメータを使用して作成される。ElasticSearchでは異なるクエリタイプを用い、あるドキュメントに対して特定のスコアを与えることを可能にする。（例としていくつかのフィルタにマッチするドキュメント。）または使用したスクリプトによりスコアを演算することも可能だ。
 
-###Real Time Get
+### Real Time Get
 
 Real time get allows us to retrieve a document using its identifier as soon as it was sent for indexing even if it hasn’t yet been hard committed. Both ElasticSearch and Apache Solr return the newest document, even if it wasn’t indexed. But lets go into specifics.
 
 リアルタイムGetはドキュメントのIDを用いて、それがインデックス作成のために送られた時に、例えハードコミットが行なわれていなくてもドキュメントの回収を可能にする。ElasticSearchとApache Solrの両方が最新のドキュメントを例え索引付けされていなくても返すことが可能だ。しかし具体的に見てみよう。
 
-####Solr
+#### Solr
 
 Introduction of so called transaction log in Solr 4.0 allowed for the real time get functionality. Basically, the real time get looks for the newest version of the document in the transaction log first and returns it as a result of such call (if it is found, of course). If it is not found the real time get handler gets the document using the latest opened searcher available. Keep in mind that in order to return the newest version of the document in near real time manner Solr doesn’t need to reopen the index after indexing, so this functionality is useful even if you don’t reopen your searcher every second.
 
 Solr4.0におけるトランザクションログと呼ばれる機能の紹介によりリアルタイムGetが利用可能になった。基本的にリアルタイムGetはドキュメントの最新バージョンをトランザクションログから最初に探しその呼出の結果として返す（もちろん見つかった場合に）もし見つからなかったらリアルタイムGetハンドラは最も最近に開かれたsearcherが存在するドキュメントを得る。覚えておいて欲しいのはほぼリアルタイムの様式最新バージョンのドキュメントを返すためにSolrはインデックス作成後にインデックスを再び開く必要がない。従ってこの機能はsearcherを毎秒再開しなくても有効である。
 
-####ElasticSearch
+#### ElasticSearch
 
 ElasticSearch also uses transaction log and because of that the real time get is not affected by the refresh rate of your indices. In addition to returning the document itself ElasticSearch exposes a few other API parameter that allow you to specify if the request should go to the primary or local shard (or even a custom one). You can also use routing with real time get to route the request to one specific shard if you know which shard should have the appropriate document. The real time get API of ElasticSearch also allows to check if the document exists using HTTP HEAD method, for example:
 
@@ -176,19 +176,19 @@ ElasticSearchもまたトランザクションログを用いているのでリ�
 
 	curl -XHEAD 'http://localhost:9200/sematext/blog/123456789'
 
-###Aliasing
+### Aliasing
 
 One of the things introduced in Apache Solr 4.0 and no available in ElasticSearch right now is the ability to transform result documents. First of all Solr allows you to alias returned fields, so for example you can return field price_usd or price_eur as price depending on your needs. The second thing is the ability to return values returned by functions as a (pseudo) field in the result (or fields). Solr also has the ability to return fields which start with a given prefix (for example all fields starting with price). Apart from the ability to get a function value as a field added to matched documents on the fly other functionalities are not ground breaking, though they can be handy in some cases.
 
 Apache Solr 4.0にて紹介されElasticSearchに現時点ではまだ存在しない機能として結果のドキュメントの変換がある。最初にSolrは返り値のフィールドに別名を付けることができる。そのため例えば必要に応じてpriceフィールドとしてprice_usdかprice_eurを返せる。2つ目に関数の返り値を（見せかけの）フィールドとして結果（またはフィールド）としてか返すことが可能だ。Solrはまた与えられた接頭子で始まるフィールド（例えばpriceで始まる全てのフィールド）を返す機能も存在する。
  
-###他
+### 他
 
 One of the things we always mention when talking about the differences between Apache Solr and ElasticSearch, at least when it comes to query handling, is the possibility of specifying the analyzer during query time. But lets start from the beginning. In Solr, you have to create the schema.xml file which holds the information about the index structure as well as query and index-time analyzers for fields. Similarly, in ElasticSearch, you can create mappings and define analyzers. At query-time Solr will choose the right analyzer for each field and use it.  ElasticSearch will do the same with one major difference. In ElasticSearch you can change the analyzer and specify the analyzer you want to use for analysis at query-time. For example, this is very useful when you know the language of the query because then you can choose the most language-appropriate analyzer on the fly.  We have made use of this in combination with our Language Identifier.
 
 Apache SolrとElasticSearchの違いについて我々が常に伝えていることの1つは、少くともクエリの取扱に関しては、クエリ時中に解析器を指定する可能性である。しかしまずは最初から始めよう。Solrではインデックス構造、それにクエリとフィールドのインデックス作成時の解析器に関する情報を持つschema.xmlファイルを作成する必要がある。同様にElasticSearchではマッピングを作成し解析器を定義する。クエリ時にSolrは各フィールドに対し適切な解析器を選択し、使用する。ElasticSearchも同じことをするが大きな違いが1つある。ElasticSearchでは解析器の変更と解析に必要な解析器の指定がクエリ時に行える。例えばクエリ対象の言語を知っている場合にこれはとても便利だ。最も言語に適切な解析器を動的に選択できるからだ。我々はこの機能を自身の言語特定機構といっしょに使用している。
 
-##まとめ
+## まとめ
 
 As you can see, both ElasticSearch and Apache Solr expose lots of functionality when it comes to handling your search queries, and we barely scratched the surface here. Of course, each of them has some features that the other one doesn’t have, but Solr and ElasticSearch are competing for mind and market share, and are both rapidly evolving and improving, so we can expect more features from both of them in the future. In the next, fourth part of the series we will concentrate on the faceting capabilities of Apache Solr and ElasticSearch.  Stay tuned.  In the mean time, you can follow @sematext and tell us what you want us to cover.
 

--- a/part4.md
+++ b/part4.md
@@ -1,4 +1,4 @@
-#Solr vs ElasticSearch: Part 4 – Faceting
+# Solr vs ElasticSearch: Part 4 – Faceting
 
 October 30, 2012 by Rafał Kuć 2 Comments
 
@@ -13,74 +13,74 @@ Solr 4 (またはSolrCloud）がリリースされた。ElasticSearch vs. Solr�
 5. Solr vs. ElasticSearch: Part 5 - Management API Capabilities
 6. Solr vs. ElasticSearch: Part 6 – User & Dev Communities Compared
 
-##Faceting
+## Faceting
 
 When it comes to faceting, both Solr and ElasticSearch have some faceting methods that other search engine does not.  Both search engines allow you to calculate facets for a given field, numerical range, or date range. The key differences are in the details, of course – in the control of how exactly the facets are calculated, in the memory footprint, and whether we can change the calculation method. In most cases ElasticSearch allows more control over faceting, however Solr has some serious advantages, too.  Lets get into details of each of the methods.
 
 facetingについてはSolrとElasticSearchの両方が他の検索エンジンが持たないいくつかのfacetingメソッドを持つ。両者の検索エンジン共が与えられたフィールド、数値範囲、日付範囲のファセットを演算することが可能である。キーとなる違いはもちろん詳細の中になり、実際にファセットがどのように演算さるかのコントロール、メモリフットプリント、そして演算手法の変更が変更できるかである。多くの場合にElasticSearchがfacetingにおいて多彩なコントロールを可能にする。しかしSolrもいくらかの重要な優位点を持っている。個々のメソッドの詳細に入ってみよう。
 
-##Term Faceting
+## Term Faceting
 
 This method of faceting allows one to get information about the number of term occurrences in a certain field.
 
 
 このfacetingのメソッドはあるフィールド内であるタームがいくつあるかの情報を得ることを可能にする。
 
-###Solr
+### Solr
 Solr let’s you control how many facets are returned, how they are sorted, the minimum quantity required, and so on. In addition to that, in Solr field faceting, you can choose between a couple of different methods for computing facets.  One of these method should be used for fields with a high number of distinct terms, while the second method is best used in the opposite scenario – when you expect relatively few distinct terms in a field being faceted on.
 
 
 Solrはファセットがいくつ返されるか、それらがどのように格納されるか、最小必要数等をコントロールできる。加えてSolrのフィールドfacetingではファセットの演算法を2、3の異なる手法の間から選択することができる。これらのメソッドの1つが最も数の多いタームに用いられ、2つ目の手法は逆のシナリオに適している。フィールド中の相対的に少ないタームがファセットされて欲しい場合である。
 
-###ElasticSearch
+### ElasticSearch
 On the other side we have ElasticSearch which allows us to do all that Solr can do (in terms of faceting calculation, not the calculation methods), but in addition it also let’s us exclude specific terms we are not interested in and use regular expressions to define which terms will be included in faceting results. In addition to that we can combine term faceting results from different field automatically or just use scripts to modify the fields values before the calculation process steps in
 
 一方、ElasticSearchではSolrができること全てが可能である。（ファセット演算に関してであり演算手法についてではない）加えて興味ない特定のタームを排他することが可能で、またファセットの結果に含まれるタームの定義に正規表現を用いることも可能だ。さらに異なるフィールドのタームfacetingの結果を自動的に連結したり、演算プロセスに入る前にフィールドの値を変更するスクリプトを使用したりもできる。
 
-##Query Faceting
+## Query Faceting
 
 Both Solr and ElasticSearch allow calculating faceting for arbitrary query results. In both cases queries can be expressed in the query API of the search engine which we use. For example, in ElasticSearch you can use the whole query DSL to calculate faceting results on them.
 
 
 SolrとElasticSearchの両方が任意のクエリの結果に対してファセットを演算できる。両者共クエリは検索エンジンのクエリAPIにて表現できる。例えばElasticSearchではクエリDSL全体をその結果のファセットの算出に用いることが可能だ。
 
-##Range Faceting
+## Range Faceting
 Range faceting lets you get the number of documents that match the given range in a field. Both engines allow for range faceting although in different fashion.
 
 レンジファセットはあるフィールドにおいて与えられた範囲にマッチするドキュメントの数を返す。両方のエンジンがレンジファセットを可能だが異なる方法で行う。
 
-###Solr
+### Solr
 
 Apache Solr lets you define the start value, end value, and the gap (with some adjustments like inclusion of values at the end of the ranges) and calculate all the ranges defined by that.
 
 Apache Solrは始まりと終わりの値、ギャップ（といくつかの調整するもの、例えば範囲の終わりの値は含まれるか否か等）を指定し、それにより定義された全ての範囲を演算する。
 
-###ElasticSearch
+### ElasticSearch
 
 ElasticSearch takes a different approach – it lets you specify set of ranges and returns document counts as well as aggregated data. In addition to that, ElasticSearch let’s you specify a different field to check if a document falls into a given range and a different field for the aggregated data calculation. Furthermore, you can modify the field and aggregated data with a script. And that’s not all – in addition to the above method of range faceting ElasticSearch also supports the so called histogram calculation.  This is similar to the Apache Solr approach – for a given field you can get a histogram of values. However, ElasticSearch doesn’t let you control the start and end like Solr does, but only the gap.
 
 ElasticSearchは異なるアプローチを取る。レンジの集合を指定しドキュメントのカウントと集約されたデータを返す。加えてElasticSearchは異なるフィールドを指定し、ドキュメントが与えられたレンジに当てはまるかチェックする他、集約データの演算に他のフィールドを指定可能だ。さらにフィールドと集約データをスクリプトで変更可能だ。それだけでなく上記のレンジファセットに加えてElasticSearchヒストグラム演算と呼ばれる物も利用できる。これはApache Solrのアプローチに似ていて与えられたフィールドの値のヒストグラムを取得できる。しかしElasticSearchはSolrのように開始値と終了値のコントロールはできず、ギャップのみである。
 
 
-##Date Faceting
+## Date Faceting
 
 Again, both search engines support faceting on date based fields.
 
 同様に両方の検索エンジンはフィールドに基づき日付のファセットをサポートする。
 
-###Solr
+### Solr
 
 Date faceting in Apache Solr is quite similar to the range faceting, although it is calculated on fields of  solr.DateField type. You have the same control and use similar parameters as withing the range faceting so I’ll omit describing it.
 
 Apache SolrのDateファセットはレンジファセットに全く同様だがsolr.DateFieldタイプのフィールド上にて演算される。レンジファセットと同様のコントロールが可能で、同様のパラメータが使用できる。そのためここでは記述を省略する。
 
-###ElasticSearch
+### ElasticSearch
 
 On the other hand, we have ElasticSearch with its date faceting which is an enhancement over the standard histogram faceting. It supports interval specification with date specific parameters like for example: year, month, or day. In addition to that, ElasticSearch lets you specify the time zone to be used in computation and of course manipulate the calculation with the use of a script.
 
 一方、ElasticSearchではdateファセットは標準のヒストグラムファセットの拡張である。日付を特定するyear、month、またはdayのようなパラメータと間隔の指定をサポートする。加えてElasticSearchは演算に用いられるタイムゾーンの指定が可能で、もちろんスクリプトを利用して演算を操作することも可能だ。
 
-###Decision Tree Faceting – Solr Only
+### Decision Tree Faceting – Solr Only
 
 One of the things that ElasticSearch lacks and that is present in Solr is the pivot faceting aka decision tree faceting. It basically lets you calculate facets inside a parents facet. For example, this is what pivot faceting results look like in Solr (n.b. this example is trimmed for this post) :
 
@@ -153,31 +153,31 @@ One of the things that ElasticSearch lacks and that is present in Solr is the pi
 	</lst>
 	</response>
 
-##Statistical Faceting
+## Statistical Faceting
 
 Both ElasticSearch and Apache Solr can compute statistical data on numeric fields – values like count, total, minimal value, maximum value, average, etc. can be computed.
 
 ElasticSearchとApache Solrの両方が統計データを数値フィールド上で演算できる。例えばカウント、総計、最小値、最大値、平均値等が演算可能である。
 
-###Solr
+### Solr
 
 In Apache Solr the functionality that enables you to calculate statistics for a numeric field is called Stats Component. It returns the above mentioned values as a part of the query result, in a separate list, just as faceting results.
 
 Apache Solrでは数値フィールドにおいて統計を演算する機能はstatsコンポーネントと呼ばれる。上で記述した値をクエリの結果の一部として、別のリストの中にファセットの結果として返す。
 
-###ElasticSearch
+### ElasticSearch
 
 In ElasticSearch this functionality is called Statistical Facet. You should keep in mind thought that, as usual, ElasticSearch allows us to calculate this information for values returned by a script or combined for multiple fields, which is very nice if you need combined information for two or more fields or you want to do additional processing before getting the data returned by ElasticSearch.
 
 ElasticSearchではこの機能はstatisticalファセットと呼ばれる。心に留めておかなければいけないのは、いつもどおり、ElasticSearchはこの情報をスクリプトの返り値に対し演算したり、複数のィールドの結合に演算可能であることである。これは2つ以上のフィールドの結合情報が必要であったり、ElasticSearchにより返された値を取得する前に追加の処理を実行したい場合にとても便利だ。
 
-##Geodistance Faceting
+## Geodistance Faceting
 
 (Geo)spatial search is quite popular nowadays where we try to provide the best search results we can and we considering multiple pieces of information and conditions. Of course both Apache Solr and ElasticSearch provide spatial search capabilities, but we are not talking about searching – we are talking about faceting. Sometimes there is a need to return a distance from a given point, just to show that in our application – and we can do that both in ElasticSearch and Solr.
 
 (Geo)spatial検索は今日とても人気がある。我々は可能な限り、複数の情報と条件によるベストの検索結果が得られるように努力している。もちろんApache SolrとElasticSearchの両方がspatial検索の能力を持つ。しかし今は検索の話はしていない。ファセットだ。我々のアプリケーションでは時々、与えられた地点からの距離を返す必要がある。ElasticSearchとSolrの両方で可能だ。
 
-###Solr
+### Solr
 
 In Solr to be able to facet by distance from a given point we would have to use facet.query parameter and use frange or geofilt, for example like this:
 Solrでは与えられた地点からの距離でファセットすることが可能だ。facet.queryパラメータを使用する必要があり、frange、geofiltを以下のように使用する
@@ -188,7 +188,7 @@ This would return the number of document within 10 kilometers from the defined p
 
 これは定義された地点より10Km以内のドキュメントの数を返す。
 
-###ElasticSearch
+### ElasticSearch
 
 ElasticSearch exposes dedicated geo_distance faceting type that lets us pass the point and the array of ranges we want the distance to be calculated for. An example query might look like this:
 
@@ -217,7 +217,7 @@ In addition to that, we can specify the units to be used in distance calculation
 
 これに加えて距離の演算に使用する単位（Kmやマイル）と距離の演算タイプを指定することができる。arcはより良い精度でplaneは演算が速い。
 
-##Solr, LocalParams and Faceting
+## Solr, LocalParams and Faceting
 
 One of the good things about faceting in Solr is that it allows the use of local params. For example, you can remove some filters from the faceting results. Imagine you have a query that gets all results for a term ‘flower’ and you only get results that fall into ‘cloth’ category and ‘shirt’ subcategory, but you would like to have faceting for tags field not narrowed to any filter. With the help of local params this query may look like this:
 
@@ -225,13 +225,13 @@ Solrのファセットにおける良い点の1つはローカルパラメータ
 
 	q=flower&fq={!tag=facet_cat}category:cloth&fq={!tag=facet_sub}subcategory:shirt&facet=true&facet.field={!ex=facet_cat,facet_sub}tags
 
-##ElasticSearch Faceting Scope and Filters
+## ElasticSearch Faceting Scope and Filters
 
 By default ElasticSearch facets are restricted to the scope of a given query, which is understandable. However, ElasticSearch also lets us change the scope of faceting to global and thus calculate the faceting for the whole data set, and not just for a given result set. In addition to that we can calculate facets for different nested objects by defining the scope matching the name of the nested object. This can come in handy in many situations, for example when optimizing memory usage on faceting on multivalued fields with many unique terms. In addition to that with ElasticSearch we can narrow down the subset of the documents on which faceting will be applied by using filters. We can define filters inside faceting (just please remember that filters that narrow down query results are not restricting faceting) and choose which documents should be taken into consideration when calculating facets. Of course, as you may expect, filters for faceting may be defined in the same way as filters for queries.
 
 デフォルトではElasticSearchのファセットは与えられたクエリのスコープに限定される。これは理解できる。しかしElasticSearchはまたファセットのスコープをグローバルに変更可能で、与えられた結果集合だけでなく全てのデータセットに対してファセットを演算することができる。さらに異なる入れ子オブジェクトに対しファセットを演算することも可能だ。入れ子オブジェクトの名前にマッチングするスコープを定義する。これが多くの場合に便利である。例えば多くの異なるタームと複数値のフィールド上でファセットを行う場合のメモリを最適化したい場合だ。加えてElasticSearchではフィルタを用いることでファセットを適用するドキュメントの部分集合を絞り込むことが可能だ。ファセットの内部でフィルタを設定可能であり（クエリの結果を絞り込むフィルタはファセットだけに限定されないことを思いだすことを願う）どのドキュメントがファセットを演算する時に考慮すべきかを選択することができる。もちろん予想されるだろうが、ファセットに対するフィルタはクエリに対するフィルタと同じようにて定義できる。
 
-##まとめ
+## まとめ
 
 In this part of the Apache Solr vs ElasticSearch posts series we talked about the ability to calculate facet information and only about this. Of course, this is only a look at the surface of faceting, because both Apache Solr and ElasticSearch provide some additional parameters and features that we couldn’t cover without turning this post into a tl;dr monster. However, we hope this post gives you some general ideas about what you can expect from each of these search engines. In the next part of the series we will focus on other search features, such as geospatial search and the administration API. If you are going to the upcoming ApacheCon EU and are interested in hearing more about how ElasticSearch and Apache Solr compare, please come to my talk titled “Battle of the giants: Apache Solr 4.0 vs ElasticSearch“. See you there!
 

--- a/part5.md
+++ b/part5.md
@@ -1,4 +1,4 @@
-#Solr vs ElasticSearch: Part 5 – Management API Capabilities
+# Solr vs ElasticSearch: Part 5 – Management API Capabilities
 
 January 8, 2013 by Rafał Kuć 3 Comments
 
@@ -13,72 +13,72 @@ In previous posts, all listed below, we’ve discussed general architecture, ful
 5. Solr vs. ElasticSearch: Part 5 – Management API Capabilities
 6. Solr vs. ElasticSearch: Part 6 – User & Dev Communities Compared
 
-##Input/Output Format
-###ElasticSearch
+## Input/Output Format
+### ElasticSearch
 
 As you probably know ElasticSearch offers a single way to talk to it – its HTTP REST API – JSON structured queries and responses. In most cases, especially during query time, it is very handy, because it let’s you perfectly control the structure of your queries and thus control the logic.
 
 ご存知かとは思うがElasticSearchは単一の通信方法を提供する。HTTP REST APIだ。JSON構造のクエリとレスポンスである。多くの場合、特にクエリ時においてとても便利だ。クエリの構造を完全にコントロール可能、従ってロジックをコントロールできるからだ。
 
-###Apache Solr
+### Apache Solr
 
 On the other hand we have Apache Solr. If you are familiar with it you know that in order to send a query to Solr one needs to send it using URL request parameters.  This makes communication much less structured compared to ElasticSearch JSON format. In response you can get multiple response formats that are supported out of the box, like the default XML, JSON, CSV, PHP serialized, or Ruby.
 
 一方のApache Solrであるが、もしそれに詳しければ、Solrにクエリを送るのにURLリクエストパラメータを送る必要があるのはご存知だろう。これがElasticSearchのJSON形式に比べるとコミュニケーションをより低い程度の構造化としてしまう。レスポンスでは素の状態で複数のレスポンス形式がサポートされている。デフォルトのXML、JSON、CSV、シリアライズされたPHP、またはRubyである。
 
 
-##Statistics API
+## Statistics API
 
 Most of the time your search cluster will be fine and you won’t have any problems with it. However, there are times where you may need to see what is happening inside Apache Solr or ElasticSearch to diagnose problems, such as performance problems (hello SPM!), stability issues, or anything like that. In such cases, both search engines provide some amount of statistics.
 
 ほとんどの場合、検索クラスタは健康で問題を起こすことはないだろう。しかしApache SolrやElasticSearchの中で何が起こっているのかを見て問題の診断を行う必要があるだろう。例えばパフォーマンス上の問題や（やぁ、 SPM!)安定性の問題、またはそのような問題全てだ。そのような場合には両方の検索エンジンはいくつかの量の統計値を提供する。
 
-###Apache Solr
+### Apache Solr
 
 In Solr we can use JMX or HTTP requests to retrieve information about handler usage, cache statistics or information about most Solr components.
 
 
 SolrではJMXやHTTPリクエストをハンドラの使用法、キャッシュの統計、または多くのSolrのコンポーネントの情報を得るのに利用できる。
 
-###ElasticSearch
+### ElasticSearch
 ElasticSearch was designed to be able to return various statistics about itself. With the REST API calls we can get information from the simplest ones like cluster health or nodes statistic, to extent information like the detailed ones about indices with merges, refreshes. The same stats are available via JMX, too.
 
 ElasticSearchはそれ自身の様々な統計を返すことができるように設計されている。REST APIの呼出を用いて最も単純な物、例えばクラスタの健康状態やノードの統計等から、インデックスのマージ、リフレッシュのような詳細な物等広範囲の情報を得ることができる。同じ情報はJMX経由でも取得可能だ。
 
 
-##Settings API
-###ElasticSearch
+## Settings API
+### ElasticSearch
 
 ElasticSearch allows us to modify most of the configuration values dynamically. For example, you can clear you caches (or just specific type of cache), you can move shards and replicas to specific nodes in your cluster. In addition to that you are also allowed to update mappings (to some extent), define warming queries (since version 0.20), etc. You can even shut down a single node or a whole cluster with the use of a single HTTP call. Of course, this is just an example and doesn’t cover all the possibilities exposed by ElasticSearch.
 
 ElasticSearchは動的に設定値の多くを変更することが可能だ。例えばキャッシュをクリアしたり、または特定のタイプのキャッシュのみをクリアしたり、Shardとレプリカをクラスタの指定したノードに移動することが可能だ。加えてある範囲のマッピングを更新したり、ウォーミングクエリ（v0.20以降）を定義したりもできる。単一ノードやクラスタ全体を一度のHTTP呼出でシャットダウンすることも可能だ。もちろんこれはただの例でありElasticSearchにより公開されている機能を全てカバーする訳ではない。
 
-###Apache Solr
+### Apache Solr
 
 In case of Apache Solr we do not (yet) have the possibility of changing configuration values (like warming queries) with API calls.
 
 Apache Solrの場合、API呼出により設定値の変更（例えばウォーミングクエリ）を行う機能は「まだ」無い
 
 
-##インデックス／コレクションの管理機能
+## インデックス／コレクションの管理機能
 In addition to the capabilities mentioned above both ElasticSearch and Apache Solr provide APIs that allows us to modify our deployment when it comes to collections and indices.
 
 上で説明した機能の他にElasticSearchとApache Solrはコレクションとインデックスに関するデプロイを変更することを可能とする。
 
-###Apache Solr
+### Apache Solr
 
 Pre 4.0 we were able to manipulate cores inside our Solr instances. We could create new cores, reload them, get their status, rename, swap two of them, and finally remove a core from the instance. With Solr 4.0, a new API was introduced that is built on top of core admin API – the collections API. It allows us to create collections on started SolrCloud cluster, reload them and of course delete them. As the collections API is built on top of the core admin API,  if you create a new collection all the needed cores on all instances will be created. Of course, the same goes for reloading and deleting – all the cores will be appropriately informed and processed.
 
 4.0以前ではSolrインスタンスの中の複数のコアを操作できた。新しいコアを作成したりリロードしたり、状態を得たり、名前変更、その内2つのスワップ、それに最終的にはインスタンスからコアを削除することができた。Solr 4.0ではコア管理APIのトップに新しいAPIが構築されて、紹介された。コレクションAPIである。開始したSolrCloudのクラスタ上にコレクションを作成すること、リロードともちろん消去もできる。コレクションAPIがコア管理APIの上に構築されて、新しいコレクションを作成すれば全てのインスタンス上の必要なコアは全て作成される。もちろん同様にリロードや削除も可能だ。全てのコアは適切に情報を受け、処理される。
 
-###ElasticSearch
+### ElasticSearch
 
 In case of ElasticSearch we can create and delete indices by running a simple HTTP command (GET or DELETE method) with the index name we are interested in. In addition to that, with a simple API call we can increase and decrease the number of replicas without the need of shutting down nodes or creating new nodes. With the newer ElasticSearch versions we can even manipulate shard placement with the cluster reroute API. With the use of that API we can move shards between nodes, we can cancel shard allocation process and we can also force shard allocation – everything on a live cluster.
 
 ElasticSearchの場合、簡単なHTTPコマンド（GET、またはDELETEメソッド）を対象とするインデックスの名前と共に実行するだけでインデックスの作成や削除が可能だ。加えて簡単なAPI呼出でレプリカの数をノードのシャットダウンや作成無しに増減することも可能だ。新しいElasticSearchのバージョンではShardの配置をクラスタのリルートAPIで行うこともできる。そのAPIの使用によりShardをノード間で移動したり、Shardの獲得手続をキャンセルしたり、または強制することも可能だ。全て運用中のクラスタ上でである。
 
-##Query Analysis
-###Apache Solr
+## Query Analysis
+### Apache Solr
 
 If you’ve used Apache Solr you probably come across the debugQuery parameter and the explainOther parameter. Those two allows to see the detailed score calculation for the given query and documents found in the results (the debugQuery parameter) and the specified ones (the explainOther). In addition, we can also see how the analysis process is done with the use of analysis handler or by using the analysis page of the Solr administration panel provided with Solr.
 
@@ -164,7 +164,7 @@ As you can see, we can get information about timings of each of the used compone
 
 ご覧のとおり、使用された各コンポーネントのタイミングに関する情報を得ることが可能だ。加えてパースされたクエリを見ることや、もちろん、どのようにドキュメントのスコアが計算されたかを知るexplain情報を見ることも可能だ。
 
-###ElasticSearch
+### ElasticSearch
 
 ElasticSearch exposes three separate REST end-points to analyze our queries, documents and explain the documents score. The Analyze API allows us to test our analyzer on a specified text in order to see how it is processed and is similar to the analysis page functionality of Solr. The Explain API provides us with information about the score calculation for a given documents. Finally, the Validate API can validate our query to see is it is proper and how expensive it can be.
 
@@ -200,13 +200,13 @@ You can see the description about score calculation that is returned from the Ex
 
 Explain APIより返されたスコア演算の記述がわかるだろう。
 
-##Before We End
+## Before We End
 
 There are a few words more we wanted to write before summarizing this comparison. First of all the above mentioned APIs and possibilities are not all that it is available, especially when it comes to ElasticSearch. For example, with ElasticSearch you can clear caches on the index level, you can check index and types existence, you can retrieve and manage your warming queries, clear the transaction log by running the Flush API, or  even close an index or open those that were closed. We wanted to point some differences and similarities between Apache Solr and ElasticSearch, but we didn’t want to make a summary of the documentation. :) So, if you are interested in some functionality and you don’t know if it exists, just send a mail to Apache Solr or ElasticSearch mailing list or leave a comment here, and we will be glad to help.
 
 この比較をまとめる前にまだ少し書いておきたいことがある。まず最初に上記にて説明したAPIと機能は存在する全ての機能ではない。特にElasticSearchにおいてそうだ。例えばElasticSearchではインデックスレベル上のキャッシュをクリアしたり存在するインデックスとタイプを確認したり、ウォーミングクエリを取得、管理したり、フラッシュAPIを実行してトランザクションログを削除したり、さらにはインデックスをクローズしたり、クローズされたものをオープンしたりも可能だ。我々はApache SolrとElasticSearchの違いや類似点を示したかった。しかし我々はドキュメントのまとめを作りたくはなかった。:-) 従ってもしある機能に興味があり、それが存在するか知らない場合はApache SolrやElasticSearchのメーリングリストにメールを投げるか、ここにコメントを残して欲しい。我々は喜んで手助けをしたい。
 
-##まとめ
+## まとめ
 
 When we first started the Solr vs ElasticSearch series we planned to initially divide the series into five posts, which are now published. However after seeing the popularity of the series and the amount of feedback we’ve received, we decided to extend the series. You can soon expect the next part, which will be dedicated to non-technical, but deeply important and interesting aspects of both search servers. After that, we’ll get back to the technical details with the subsequent post  dedicated to score influence capabilities, describing how we can change the default Lucene scoring and influence it from configuration, during indexing time and finally during querying.
 

--- a/part6.md
+++ b/part6.md
@@ -1,4 +1,4 @@
-#Solr vs. ElasticSearch: Part 6 – ユーザと開発者コミュニティ
+# Solr vs. ElasticSearch: Part 6 – ユーザと開発者コミュニティ
 
 January 22, 2013 by Rafał Kuć 2 Comments
 
@@ -13,26 +13,26 @@ One of the questions after my talk during the recent ApacheCon EU was what I tho
 5. Solr vs. ElasticSearch: Part 5 – Management API Capabilities
 6. Solr vs. ElasticSearch: Part 6 – User & Dev Communities Compared
 
-##ユーザコミュニティ
+## ユーザコミュニティ
 
 Let’s start by discussing the user activity around both ElasticSearch and Apache Solr.
 
 ElasticSearchとApache Solrの両方のユーザの活動についての議論から始めてみよう。
 
-###ユーザアクティビティ
+### ユーザアクティビティ
 
 We started working on this post right before the Christmas break of 2012. During that time we decided to see how active the user base was for both ElasticSearch and Apache Solr. To do that we used our handy search-lucene.com service and we compared the number of email messages sent to both user list. So let’s see how they stack up.
 
 我々はこの記事についての活動を2012年のクリスマス休暇の前に始めた。その間我々はユーザベースがElasticSearchとApache Solrの両者についてどの程度活発であるかを調べることにした。それを行うために我々の便利なsearch-lucene.comサービスを使用し、両者のメーリングリストに送られたE-mailメッセージの数を比べてみた。まずそれらがどのように異なるか見てみよう。
 
-####Apache Solr
+#### Apache Solr
 ![](solr_user.png)
 
 As you can see, Solr user activity varies slightly from month to month which is perfectly understandable. Each bar on the chart represents two weeks. We can see the number of messages ranges from about 390 mails to about 770 per two weeks, which gives us between 800 to 1600 mails per month is we do a bit of rounding up. Quite impressive I must say!
 
 ご覧のとおり、Solrのユーザアクティビティは月々ではっきりと異なることがとても良く理解できる。チャート上の各棒が二週間を示す。メッセージ数の範囲は二週間毎に約390通から約770通であり、月当たりでは800から1600通になることがとりあえずのまとめだ。とても印象的だと言えるだろう。
 
-####ElasticSearch
+#### ElasticSearch
 ![ElasticSearch User Mailing List](es_user.png)
 
 Now let’s discuss the ElasticSearch side. First a few words of explanation. If you look at the above chart you might think that ElasticSearch mailing list was silent and then users started posting on October 2012. That’s clearly not true – it is just that we didn’t add ElasticSearch to search-lucene.com until recently.  However, you may see that the number of messages during the same period of time is quite similar – both Solr and ElasticSearch saw about 670 – 730 messages during a two weeks period. This gives us 2 emails per hour on average.
@@ -40,30 +40,30 @@ Now let’s discuss the ElasticSearch side. First a few words of explanation. If
 
 ElasticSearchの側について議論しよう。最初に少しだけ説明を行うと、上のチャートを見るとElasticSearchのMLは静かでユーザは2012年10月に投稿を開始したと思うかもしれない。それは全く正しくない。これはただ我々がElasticSearchをつい最近までsearch-lucene.comに追加しなかったためだ。しかし同じ期間のメッセージの数はとても似ていることにも気がつくだろう。SolrとElasticSearchは約670から730通を二週間の間に見ている。これは平均で1時間当たりに2通となる。
 
-###個別のユーザ数
+### 個別のユーザ数
 Email volume is one thing, but I was always curious about how many different people write emails on the mailing lists. Having such number would give us an additional understanding of the structure of the community around a particular search engine, new users, etc. However, we should not look only at this number, but also on things like most active people on the mailing lists. In both cases we’ve looked at the same period from 1 to 30 December 2012. We’ve used the data we index for search-lucene.com to calculate these numbers.
 
 電子メールの数は1つの指標だ。しかし私は常にどれだけの異なる人がメーリングリストに書いているのかに興味があった。そのような数字を持つことにより検索エンジンや新しいユーザに関するコミュニティの構造についてより深い理解が得られる。しかしこの数字だけを見るのではなく、最もアクティブなML上の人々等も参照しよう。両方のケースについて2012年12月1日から30日という同じ期間において調べた。使用したデータは我々がsearch-lucene.comにてこれらの数字を計算するためにインデックス作成した物だ。
 
-####Apache Solr
+#### Apache Solr
 
 In case of Apache Solr there were 234 unique users sending mail to the users mailing list. Almost 8 unique users per day on average, nice :)
 
 Apache Solrでは234人の独立したユーザがユーザメーリングリストにメールを送っていた。平均で1日に約8人の独立したユーザである。素晴しい :)
 
-####ElasticSearch
+#### ElasticSearch
 
 In case of ElasticSearch there were 271 unique users sending mail to the users mailing list. This gives us about 9 unique users per day on average which is even nicer.
 
 ElasticSearchの場合、271人の独立したユーザがユーザメーリングリストにメールを投稿していた。平均で1日当たり約9人であり、より良い。
 
-##使用可能なリソース
+## 使用可能なリソース
 
 As far as resources available, both ElasticSearch and Solr have great documentation. On Solr wiki site (http://wiki.apache.org/solr/) you can find information about most of the components and of course the tutorial for beginners. ElasticSearch is very similar, with tutorial and very good description of functionality available at http://www.elasticsearch.org/. In addition to that, there are three books published about Apache Solr (in English) and more (e.g. my Apache Solr 4 Cookbook) coming soon. As of now, there are no published books about ElasticSearch, but…. stay tuned :)
 
 使用可能なリソースに関して、ElasticSearchとSolrの両方がとても良いドキュメントを持っている。Solr Wiki Site(http://wiki.apache.org/solr/)ではほとんどのコンポーネントともちろん初心者向けチュートリアルに関する情報が見つけられる。ElasticSearchも同様でチュートリアルととても良い機能説明がhttp://www.elasticsearch.org/に存在する。加えてApach Solrには（英語の）本が3冊出版されており、さらに（例えば私のApache Solr 4 Cookbook）がすぐに用意される予定だ。現在の所ElasticSearchに関する本はまだ出版されていないが、しかし、、乞うご期待。:)
 
-##検索上のトレンド
+## 検索上のトレンド
 
 We also decided to use uncle Google to look at trends about Apache Solr and ElasticSearch. Let’s look at the following diagram:
 
@@ -79,15 +79,15 @@ Of course, the above doesn’t say anything about the number of users of both se
 
 もちろん上記は両検索エンジンのユーザ数については何も言えない。しかし両者の技術に対する興味を示すいくらかの情報であることは決定的である。
 
-##開発者とコード
+## 開発者とコード
 
 If you are familiar with ElasticSearch and Solr you’ll probably know that ElasticSearch is much younger than Apache Solr. Apache Solr was created by Yonik Seeley in 2004 and donated to Apache Software Foundation. On the other hand, the first version of ElasticSearch was released by Shay Banon in 2010. This is quite important to say before we can talk about differences about contributors and the code itself. But getting to the point – we thought that it may be interesting to see both Apache Solr and ElasticSearch look from the Bird’s Eye perspective. To do that we’ve used the statistics and charts from ohloh.net. So, let’s see what they look like.
 
 もしあなたがElasticSearchとSolrに親しみがあれば恐らくElasticsearchのほうがApache Solrに比べて若いことを知っているだろう。Apache SolrはYonik Seeleyにより2004年に作成されApacheソフトウェア財団に寄贈された。一方、ElasticSearchの最初のバージョンは2010年にShay Banonによりリリースされた。これは貢献者とコード自身の違いについて議論する前にとても重要なことだ。しかしその点に移る前にApache SolrとElasticSearchを俯瞰的に見ると面白いだろうと考える。そうするためにohloh.netから統計とグラフを使用した。早速、それらがどのように見えるか見てみよう。
 
 
-###Apache Solr
-####コード上の統計
+### Apache Solr
+#### コード上の統計
 
 If we look at the current statistics, at the beginning of January 2013 Solr had more than 212k lines of code, with almost 7000 commits and 38 contributors. However, keep in mind that contributors are people that committed the code, not necessarily the ones that actually implemented it and provided the patch, so the actual number of contributors is much higher. The chart looks like this: !
 
@@ -96,14 +96,14 @@ If we look at the current statistics, at the beginning of January 2013 Solr had 
 ![lines_of_code_solr](lines_of_code_solr1.png)
 
 
-####トップ貢献者
+#### トップ貢献者
 If we look at top contributors we see Mark Miller on top, followed by Yonik Seeley and Robert Muir in the third place :)
 
 トップ貢献者を見ればMark Millerがトップだ。続いてYonik Seeley、そしてRobert Muirが3位につけている。:)
 ![Active Contributors](top_commiters_solr.png)
 
 
-####活動的貢献者
+#### 活動的貢献者
 One more interesting thing is the number of contributors that were actively involved during a given period of time. Looking at Apache Solr since 2006 we can see the following: active_commiters_solr I think that we can say that we had a stable growth of active contributors starting from 2006 until June 2012 with a bit of downfall shortly after that. However I don’t think that the number active contributors will be dropping, it’s more likely due to a bit of exhaustion of releasing Apache Lucene and Solr 4.0 :)
 
 もう一つ面白いことはある期間の間に実際に関係した貢献者数だ。Apache Solrに関して2006年から見てみると次の事実がわかる：
@@ -111,8 +111,8 @@ One more interesting thing is the number of contributors that were actively invo
 
 ![](active_commiters_solr.png)
 
-###ElasticSearch
-####コード上の統計
+### ElasticSearch
+#### コード上の統計
 
 Current code statistics for ElasticSeach shows that the code base just hit the 240k LOC  with about 4.2k commits and 87 contributors. lines_of_code_es
 
@@ -120,14 +120,14 @@ Current code statistics for ElasticSeach shows that the code base just hit the 2
 
 ![](lines_of_code_es.png)
 
-####トップ貢献者
+#### トップ貢献者
 As we’d expect, Shay Banon is the top contributor to ElasticSearch. In the second place on the podium we have Martijn van Groningen and Igor Motov in the third place: 
 
 予期したとおり、Shay BanonがElasticSearchに対するトップ貢献者である。二位にはMartijn van Groningenであり、三位にIgor Motovだ。
 
 ![](top_commiters_es.png)
 
-#####Active Contributors
+##### Active Contributors
 
 And finally the active contributors. We don’t have the same time frame comparing to Apache Solr, which is understandable as ElasticSearch is younger, but still we can see what is happening. active_commiters_es As you can see from the first quarter of 2011 there was a number of active contributors varying from 5 to about 10 with the top at the same time as in Solr – 12 active contributors in June 2012.
 
@@ -137,7 +137,7 @@ And finally the active contributors. We don’t have the same time frame compari
 
 2011の最初の四半期から見られるとおり、アクティブな貢献者の数は5から約10にまで変化しておりSolrと同時期の7月に最大の12人を記録している。
 
-##まとめ
+## まとめ
 
 As everything in this post indicates, both projects’ development and user communities are strong, active, and about equal. 2013 will be an interesting year for both projects.
 


### PR DESCRIPTION
Markdownのフォーマットについての修正です。
見出しの部分の記述が正しく描画されなくなってしまっていたので，正しく描画されるように半角スペースを挿入しました。

## Before

<img width="911" alt="elasticsearch_vs_solr_part1_md_at_master_ _minghai_elasticsearch_vs_solr" src="https://user-images.githubusercontent.com/10899437/32529197-7bf63850-c47a-11e7-94d7-82e26df9b7d2.png">

## After

<img width="923" alt="elasticsearch_vs_solr_part1_md_at_fix-for-md-format_ _shyazusa_elasticsearch_vs_solr" src="https://user-images.githubusercontent.com/10899437/32529206-8c074d24-c47a-11e7-92b1-80c55c6b14ec.png">

良ければご確認をお願いいたします。 🙇 